### PR TITLE
Import to Attribute Error

### DIFF
--- a/krypy/utils.py
+++ b/krypy/utils.py
@@ -20,7 +20,7 @@ try:
     # http://docs.scipy.org/doc/scipy-dev/reference/release.0.12.0.html#fblas-and-cblas
     import scipy.linalg.blas as blas
     blas = blas.cblas
-except ImportError:
+except AttributeError:
     import scipy.linalg.blas as blas
 
 __all__ = ['ArgumentError', 'AssumptionError', 'ConvergenceError',


### PR DESCRIPTION
This should be the right exception to catch. 

Works for me with scipy version `0.17.0.dev0+324ac7a`

(`ImportError` did not)