### PR TITLE
[utils] drop support for scipy 0.12

### DIFF
--- a/krypy/utils.py
+++ b/krypy/utils.py
@@ -15,13 +15,7 @@ from scipy.sparse.sputils import isintlike
 from collections import defaultdict
 
 # for Givens rotations
-try:
-    # scipy < 0.12, compare
-    # http://docs.scipy.org/doc/scipy-dev/reference/release.0.12.0.html#fblas-and-cblas
-    import scipy.linalg.blas as blas
-    blas = blas.cblas
-except ImportError:
-    import scipy.linalg.blas as blas
+import scipy.linalg.blas as blas
 
 __all__ = ['ArgumentError', 'AssumptionError', 'ConvergenceError',
            'LinearOperatorError', 'InnerProductError', 'RuntimeError',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='krypy',
       author='André Gaul',
       author_email='gaul@web-yard.de',
       url='https://github.com/andrenarchy/krypy',
-      requires=['numpy (>=1.7)', 'scipy (>=0.12)'],
+      requires=['numpy (>=1.7)', 'scipy (>=0.13)'],
       classifiers=[
           'Development Status :: 4 - Beta',
           'Intended Audience :: Science/Research',


### PR DESCRIPTION
Instead of fixing my ugly hack for scipy 0.12 (see #48), I'm removing support for 0.12. The current scipy version is 0.16 and we now require 0.13 in krypy.