### PR TITLE
don't create readme.rst for pypi; it supports markdown for while now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-
 default:
 	@echo "\"make upload\"?"
 
-README.rst: README.md
-	pandoc README.md -o README.rst
-	python setup.py check -r -s || exit 1
-
-upload: setup.py README.rst
-	python setup.py sdist upload --sign
+upload: clean setup.py
+	# Make sure we're on the master branch
+	@if [ "$(shell git rev-parse --abbrev-ref HEAD)" != "master" ]; then exit 1; fi
+	rm -f dist/*
+	python3 setup.py sdist
+	python3 setup.py bdist_wheel
+	twine upload dist/*
 
 clean:
-	rm -f README.rst
+	@find . | grep -E "(__pycache__|\.pyc|\.pyo$\)" | xargs rm -rf
+	@rm -rf *.egg-info/ build/ dist/

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-import codecs
 
 # Use setuptools for these commands (they don't work well or at all
 # with distutils).  For normal builds use distutils.
@@ -10,23 +8,11 @@ except ImportError:
     from distutils.core import setup
 
 
-# shamelessly copied from VoroPy
-def read(fname):
-    try:
-        content = codecs.open(
-            os.path.join(os.path.dirname(__file__), fname),
-            encoding='utf-8'
-            ).read()
-    except Exception:
-        content = ''
-    return content
-
-
 setup(name='krypy',
       packages=['krypy', 'krypy.recycling'],
       version='2.1.7',
       description='Krylov subspace methods for linear systems',
-      long_description=read('README.rst'),
+      long_description=open('README.md').read(),
       author='André Gaul',
       author_email='gaul@web-yard.de',
       url='https://github.com/andrenarchy/krypy',


### PR DESCRIPTION
Now that Python 2 reached EOL, one might also add something like `python_requires=">=3.6"` to `setup.py`, but I didn't want to jump the gun here.