### PR TITLE
add convenience wrappers for easy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ out = krypy.gmres(A, b)
 
 # plot residuals
 import matplotlib.pyplot as plt
-plt.semilogy(sol.resnorms)
+plt.semilogy(out.resnorms)
 plt.show()
 ```
 Of course, this is just a toy example where you would not use GMRES in

--- a/README.md
+++ b/README.md
@@ -40,13 +40,12 @@ import krypy
 A = numpy.diag([1.0e-3] + list(range(2, 101)))
 b = numpy.ones(100)
 
-# out = krypy.cg(A, b)
-# out = krypy.minres(A, b)
-out = krypy.gmres(A, b)
+# sol, out = krypy.cg(A, b)
+# sol, out = krypy.minres(A, b)
+sol, out = krypy.gmres(A, b)
 
-# out.xk contains the last iterate (ideally the solution),
-# out.resnorms the relative residual norms;
-# there's plenty more
+# sol is None if no solution has been found
+# out.resnorms the relative residual norms and some more data
 
 # plot residuals
 import matplotlib.pyplot as plt

--- a/README.md
+++ b/README.md
@@ -35,17 +35,23 @@ method is used to solve the linear system `A*x=b` with the diagonal matrix
 `A=diag(1e-3,2,...,100)` and right hand side `b=[1,...,1]`.
 ```python
 import numpy
-from krypy.linsys import LinearSystem, Gmres
+import krypy
 
-# create linear system and solve
-linear_system = LinearSystem(A=numpy.diag([1e-3]+range(2, 101)),
-                             b=numpy.ones((100, 1)))
-sol = Gmres(linear_system)
+A = numpy.diag([1.0e-3] + list(range(2, 101)))
+b = numpy.ones(100)
+
+# out = krypy.cg(A, b)
+# out = krypy.minres(A, b)
+out = krypy.gmres(A, b)
+
+# out.xk contains the last iterate (ideally the solution),
+# out.resnorms the relative residual norms;
+# there's plenty more
 
 # plot residuals
-from matplotlib import pyplot
-pyplot.semilogy(sol.resnorms)
-pyplot.show()
+import matplotlib.pyplot as plt
+plt.semilogy(sol.resnorms)
+plt.show()
 ```
 Of course, this is just a toy example where you would not use GMRES in
 practice. KryPy can handle arbitrary large matrices - as long as the (hopefully

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,15 +50,28 @@ Solve a linear system
 The following code uses MINRES to solves a linear system with an indefinite
 diagonal matrix::
 
-  from numpy import diag, linspace, ones, eye
-  from krypy.linsys import LinearSystem, Minres
+  from numpy import diag, linspace, ones
+  import krypy
 
   # construct the linear system
   A = diag(linspace(1, 2, 20))
   A[0, 0] = -1e-5
   b = ones(20)
-  linear_system = LinearSystem(A, b, self_adjoint=True)
+  sol, out = krypy.minres(A, b)
 
+The variable ``sol`` contains the solution as a ``numpy.array``, ``out`` holds more
+information like the residual norms etc.
+
+For advanced usage, you can create a ``LinearSystem`` object to feed into the solver::
+
+  from numpy import diag, linspace, ones
+  from krypy.linsys import LinearSystem, Minres
+
+  A = diag(linspace(1, 2, 20))
+  A[0, 0] = -1e-5
+  b = ones(20)
+
+  linear_system = LinearSystem(A, b, self_adjoint=True)
   # solve the linear system (approximate solution is solver.xk)
   solver = Minres(linear_system)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,8 @@ diagonal matrix::
 The variable ``sol`` contains the solution as a ``numpy.array``, ``out`` holds more
 information like the residual norms etc.
 
-For advanced usage, you can create a ``LinearSystem`` object to feed into the solver::
+The above example uses the convenience function ``krypy.minres``. For advanced use
+you can use the ``krypy.linsys.Minres`` with a ``LinearSystem``:
 
   from numpy import diag, linspace, ones
   from krypy.linsys import LinearSystem, Minres

--- a/krypy/__init__.py
+++ b/krypy/__init__.py
@@ -1,3 +1,5 @@
 from . import linsys, deflation, recycling, utils
-__all__ = ['linsys', 'deflation', 'recycling', 'utils']
+from ._convenience import cg, minres, gmres
+
+__all__ = ['linsys', 'deflation', 'recycling', 'utils', 'cg', 'minres', 'gmres']
 __version__ = '2.1.7'

--- a/krypy/_convenience.py
+++ b/krypy/_convenience.py
@@ -11,7 +11,6 @@ def wrap_inner_product(inner):
         if a.shape[1] == 0:
             return numpy.array([[]])
         return numpy.array([[inner(a[:, 0], b[:, 0])]])
-
     return _wrap
 
 
@@ -75,13 +74,7 @@ def cg(
             explicit_residual=use_explicit_residual,
             store_arnoldi=store_arnoldi,
         )
-
-    # Flatten a bunch of unnecessarily augmented vectors
-    out.x0 = out.x0.reshape(b.shape)
-    out.xk = out.xk.reshape(b.shape)
-    out.MMlr0 = out.MMlr0.reshape(b.shape)
-    out.Mlr0 = out.Mlr0.reshape(b.shape)
-    return out
+    return out.xk.reshape(b.shape) if out.resnorms[-1] < out.tol else None, out
 
 
 def minres(
@@ -146,13 +139,7 @@ def minres(
             explicit_residual=use_explicit_residual,
             store_arnoldi=store_arnoldi,
         )
-
-    # Flatten a bunch of unnecessarily augmented vectors
-    out.x0 = out.x0.reshape(b.shape)
-    out.xk = out.xk.reshape(b.shape)
-    out.MMlr0 = out.MMlr0.reshape(b.shape)
-    out.Mlr0 = out.Mlr0.reshape(b.shape)
-    return out
+    return out.xk.reshape(b.shape) if out.resnorms[-1] < out.tol else None, out
 
 
 def gmres(
@@ -215,10 +202,4 @@ def gmres(
             explicit_residual=use_explicit_residual,
             store_arnoldi=store_arnoldi,
         )
-
-    # Flatten a bunch of unnecessarily augmented vectors
-    out.x0 = out.x0.reshape(b.shape)
-    out.xk = out.xk.reshape(b.shape)
-    out.MMlr0 = out.MMlr0.reshape(b.shape)
-    out.Mlr0 = out.Mlr0.reshape(b.shape)
-    return out
+    return out.xk.reshape(b.shape) if out.resnorms[-1] < out.tol else None, out

--- a/krypy/_convenience.py
+++ b/krypy/_convenience.py
@@ -1,37 +1,6 @@
 from .linsys import LinearSystem, Cg, Minres, Gmres
 from .deflation import DeflatedCg, DeflatedMinres, DeflatedGmres
-from .utils import LinearOperator as KrypyLinearOperator
 import numpy
-
-
-class LinearOperator(object):
-    def __init__(self, shape, dtype, dot=None, dot_adj=None):
-        self.shape = shape
-        self.dtype = dtype
-        self.dot = dot
-        self.dot_adj = dot_adj
-
-    def __mul__(self, X):
-        return self.dot(X)
-
-
-def wrap_linear_operator(linear_operator):
-    """Wrap the LinearOperator. This is essentially just reshaping.
-    """
-
-    def dot(X):
-        assert X.shape[1] == 1
-        out = linear_operator.dot(X[:, 0])
-        return out.reshape(-1, 1)
-
-    def dot_adj(X):
-        assert X.shape[1] == 1
-        out = linear_operator.dot_adj(X[:, 0])
-        return out.reshape(-1, 1)
-
-    return KrypyLinearOperator(
-        linear_operator.shape, linear_operator.dtype, dot, dot_adj
-    )
 
 
 def wrap_inner_product(inner):
@@ -62,21 +31,6 @@ def cg(
     assert len(A.shape) == 2
     assert A.shape[0] == A.shape[1]
     assert A.shape[1] == b.shape[0]
-
-    if isinstance(A, LinearOperator):
-        A = wrap_linear_operator(A)
-
-    if isinstance(M, LinearOperator):
-        M = wrap_linear_operator(M)
-
-    if isinstance(Minv, LinearOperator):
-        Minv = wrap_linear_operator(Minv)
-
-    if isinstance(Ml, LinearOperator):
-        Ml = wrap_linear_operator(Ml)
-
-    if isinstance(Mr, LinearOperator):
-        Mr = wrap_linear_operator(Mr)
 
     if inner_product:
         inner_product = wrap_inner_product(inner_product)
@@ -148,21 +102,6 @@ def minres(
     assert A.shape[0] == A.shape[1]
     assert A.shape[1] == b.shape[0]
 
-    if isinstance(A, LinearOperator):
-        A = wrap_linear_operator(A)
-
-    if isinstance(M, LinearOperator):
-        M = wrap_linear_operator(M)
-
-    if isinstance(Minv, LinearOperator):
-        Minv = wrap_linear_operator(Minv)
-
-    if isinstance(Ml, LinearOperator):
-        Ml = wrap_linear_operator(Ml)
-
-    if isinstance(Mr, LinearOperator):
-        Mr = wrap_linear_operator(Mr)
-
     if inner_product:
         inner_product = wrap_inner_product(inner_product)
 
@@ -233,21 +172,6 @@ def gmres(
     assert len(A.shape) == 2
     assert A.shape[0] == A.shape[1]
     assert A.shape[1] == b.shape[0]
-
-    if isinstance(A, LinearOperator):
-        A = wrap_linear_operator(A)
-
-    if isinstance(M, LinearOperator):
-        M = wrap_linear_operator(M)
-
-    if isinstance(Minv, LinearOperator):
-        Minv = wrap_linear_operator(Minv)
-
-    if isinstance(Ml, LinearOperator):
-        Ml = wrap_linear_operator(Ml)
-
-    if isinstance(Mr, LinearOperator):
-        Mr = wrap_linear_operator(Mr)
 
     if inner_product:
         inner_product = wrap_inner_product(inner_product)

--- a/krypy/_convenience.py
+++ b/krypy/_convenience.py
@@ -3,10 +3,13 @@ from .deflation import DeflatedCg, DeflatedMinres, DeflatedGmres
 import numpy
 
 
+# The simplest inner product, `numpy.dot`, should work as an input.
+# krypy assumes that the inner product _always_ returns a 2D matrix which is why we need
+# to wrap.
 def wrap_inner_product(inner):
     def _wrap(a, b):
         if a.shape[1] == 0:
-            return numpy.array([[]]).T
+            return numpy.array([[]])
         return numpy.array([[inner(a[:, 0], b[:, 0])]])
 
     return _wrap
@@ -39,7 +42,7 @@ def cg(
     if U is not None:
         U = U.reshape(U.shape[0], -1)
     if x0 is not None:
-        x0 = x0.reshape(U.shape[0], -1)
+        x0 = x0.reshape(x0.shape[0], -1)
 
     linear_system = LinearSystem(
         A=A,
@@ -74,10 +77,10 @@ def cg(
         )
 
     # Flatten a bunch of unnecessarily augmented vectors
-    out.x0 = out.x0.reshape(-1)
-    out.xk = out.xk.reshape(-1)
-    out.MMlr0 = out.MMlr0.reshape(-1)
-    out.Mlr0 = out.Mlr0.reshape(-1)
+    out.x0 = out.x0.reshape(b.shape)
+    out.xk = out.xk.reshape(b.shape)
+    out.MMlr0 = out.MMlr0.reshape(b.shape)
+    out.Mlr0 = out.Mlr0.reshape(b.shape)
     return out
 
 
@@ -109,7 +112,7 @@ def minres(
     if U is not None:
         U = U.reshape(U.shape[0], -1)
     if x0 is not None:
-        x0 = x0.reshape(U.shape[0], -1)
+        x0 = x0.reshape(x0.shape[0], -1)
 
     linear_system = LinearSystem(
         A=A,
@@ -145,10 +148,10 @@ def minres(
         )
 
     # Flatten a bunch of unnecessarily augmented vectors
-    out.x0 = out.x0.reshape(-1)
-    out.xk = out.xk.reshape(-1)
-    out.MMlr0 = out.MMlr0.reshape(-1)
-    out.Mlr0 = out.Mlr0.reshape(-1)
+    out.x0 = out.x0.reshape(b.shape)
+    out.xk = out.xk.reshape(b.shape)
+    out.MMlr0 = out.MMlr0.reshape(b.shape)
+    out.Mlr0 = out.Mlr0.reshape(b.shape)
     return out
 
 
@@ -180,7 +183,7 @@ def gmres(
     if U is not None:
         U = U.reshape(U.shape[0], -1)
     if x0 is not None:
-        x0 = x0.reshape(U.shape[0], -1)
+        x0 = x0.reshape(x0.shape[0], -1)
 
     linear_system = LinearSystem(
         A=A,
@@ -214,8 +217,8 @@ def gmres(
         )
 
     # Flatten a bunch of unnecessarily augmented vectors
-    out.x0 = out.x0.reshape(-1)
-    out.xk = out.xk.reshape(-1)
-    out.MMlr0 = out.MMlr0.reshape(-1)
-    out.Mlr0 = out.Mlr0.reshape(-1)
+    out.x0 = out.x0.reshape(b.shape)
+    out.xk = out.xk.reshape(b.shape)
+    out.MMlr0 = out.MMlr0.reshape(b.shape)
+    out.Mlr0 = out.Mlr0.reshape(b.shape)
     return out

--- a/krypy/_convenience.py
+++ b/krypy/_convenience.py
@@ -1,0 +1,297 @@
+from .linsys import LinearSystem, Cg, Minres, Gmres
+from .deflation import DeflatedCg, DeflatedMinres, DeflatedGmres
+from .utils import LinearOperator as KrypyLinearOperator
+import numpy
+
+
+class LinearOperator(object):
+    def __init__(self, shape, dtype, dot=None, dot_adj=None):
+        self.shape = shape
+        self.dtype = dtype
+        self.dot = dot
+        self.dot_adj = dot_adj
+
+    def __mul__(self, X):
+        return self.dot(X)
+
+
+def wrap_linear_operator(linear_operator):
+    """Wrap the LinearOperator. This is essentially just reshaping.
+    """
+
+    def dot(X):
+        assert X.shape[1] == 1
+        out = linear_operator.dot(X[:, 0])
+        return out.reshape(-1, 1)
+
+    def dot_adj(X):
+        assert X.shape[1] == 1
+        out = linear_operator.dot_adj(X[:, 0])
+        return out.reshape(-1, 1)
+
+    return KrypyLinearOperator(
+        linear_operator.shape, linear_operator.dtype, dot, dot_adj
+    )
+
+
+def wrap_inner_product(inner):
+    def _wrap(a, b):
+        if a.shape[1] == 0:
+            return numpy.array([[]]).T
+        return numpy.array([[inner(a[:, 0], b[:, 0])]])
+
+    return _wrap
+
+
+def cg(
+    A,
+    b,
+    M=None,
+    Minv=None,
+    Ml=None,
+    Mr=None,
+    inner_product=None,
+    exact_solution=None,
+    x0=None,
+    U=None,
+    tol=1e-5,
+    maxiter=None,
+    use_explicit_residual=False,
+    store_arnoldi=False,
+):
+    assert len(A.shape) == 2
+    assert A.shape[0] == A.shape[1]
+    assert A.shape[1] == b.shape[0]
+
+    if isinstance(A, LinearOperator):
+        A = wrap_linear_operator(A)
+
+    if isinstance(M, LinearOperator):
+        M = wrap_linear_operator(M)
+
+    if isinstance(Minv, LinearOperator):
+        Minv = wrap_linear_operator(Minv)
+
+    if isinstance(Ml, LinearOperator):
+        Ml = wrap_linear_operator(Ml)
+
+    if isinstance(Mr, LinearOperator):
+        Mr = wrap_linear_operator(Mr)
+
+    if inner_product:
+        inner_product = wrap_inner_product(inner_product)
+
+    # Make sure that the input vectors have two dimensions
+    if U is not None:
+        U = U.reshape(U.shape[0], -1)
+    if x0 is not None:
+        x0 = x0.reshape(U.shape[0], -1)
+
+    linear_system = LinearSystem(
+        A=A,
+        b=b,
+        M=M,
+        Minv=Minv,
+        Ml=Ml,
+        ip_B=inner_product,
+        # Setting those to `True` simply avoids a warning.
+        self_adjoint=True,
+        positive_definite=True,
+        exact_solution=exact_solution,
+    )
+    if U is None:
+        out = Cg(
+            linear_system,
+            x0=x0,
+            tol=tol,
+            maxiter=maxiter,
+            explicit_residual=use_explicit_residual,
+            store_arnoldi=store_arnoldi,
+        )
+    else:
+        out = DeflatedCg(
+            linear_system,
+            x0=x0,
+            U=U,
+            tol=tol,
+            maxiter=maxiter,
+            explicit_residual=use_explicit_residual,
+            store_arnoldi=store_arnoldi,
+        )
+
+    # Flatten a bunch of unnecessarily augmented vectors
+    out.x0 = out.x0.reshape(-1)
+    out.xk = out.xk.reshape(-1)
+    out.MMlr0 = out.MMlr0.reshape(-1)
+    out.Mlr0 = out.Mlr0.reshape(-1)
+    return out
+
+
+def minres(
+    A,
+    b,
+    M=None,
+    Minv=None,
+    Ml=None,
+    Mr=None,
+    inner_product=None,
+    exact_solution=None,
+    ortho="mgs",
+    x0=None,
+    U=None,
+    tol=1e-5,
+    maxiter=None,
+    use_explicit_residual=False,
+    store_arnoldi=False,
+):
+    assert len(A.shape) == 2
+    assert A.shape[0] == A.shape[1]
+    assert A.shape[1] == b.shape[0]
+
+    if isinstance(A, LinearOperator):
+        A = wrap_linear_operator(A)
+
+    if isinstance(M, LinearOperator):
+        M = wrap_linear_operator(M)
+
+    if isinstance(Minv, LinearOperator):
+        Minv = wrap_linear_operator(Minv)
+
+    if isinstance(Ml, LinearOperator):
+        Ml = wrap_linear_operator(Ml)
+
+    if isinstance(Mr, LinearOperator):
+        Mr = wrap_linear_operator(Mr)
+
+    if inner_product:
+        inner_product = wrap_inner_product(inner_product)
+
+    # Make sure that the input vectors have two dimensions
+    if U is not None:
+        U = U.reshape(U.shape[0], -1)
+    if x0 is not None:
+        x0 = x0.reshape(U.shape[0], -1)
+
+    linear_system = LinearSystem(
+        A=A,
+        b=b,
+        M=M,
+        Minv=Minv,
+        Ml=Ml,
+        ip_B=inner_product,
+        # setting self_adjoin=True avoids a warning
+        self_adjoint=True,
+        exact_solution=exact_solution,
+    )
+    if U is None:
+        out = Minres(
+            linear_system,
+            ortho=ortho,
+            x0=x0,
+            tol=tol,
+            maxiter=maxiter,
+            explicit_residual=use_explicit_residual,
+            store_arnoldi=store_arnoldi,
+        )
+    else:
+        out = DeflatedMinres(
+            linear_system,
+            ortho=ortho,
+            x0=x0,
+            U=U,
+            tol=tol,
+            maxiter=maxiter,
+            explicit_residual=use_explicit_residual,
+            store_arnoldi=store_arnoldi,
+        )
+
+    # Flatten a bunch of unnecessarily augmented vectors
+    out.x0 = out.x0.reshape(-1)
+    out.xk = out.xk.reshape(-1)
+    out.MMlr0 = out.MMlr0.reshape(-1)
+    out.Mlr0 = out.Mlr0.reshape(-1)
+    return out
+
+
+def gmres(
+    A,
+    b,
+    M=None,
+    Minv=None,
+    Ml=None,
+    Mr=None,
+    inner_product=None,
+    exact_solution=None,
+    ortho="mgs",
+    x0=None,
+    U=None,
+    tol=1e-5,
+    maxiter=None,
+    use_explicit_residual=False,
+    store_arnoldi=False,
+):
+    assert len(A.shape) == 2
+    assert A.shape[0] == A.shape[1]
+    assert A.shape[1] == b.shape[0]
+
+    if isinstance(A, LinearOperator):
+        A = wrap_linear_operator(A)
+
+    if isinstance(M, LinearOperator):
+        M = wrap_linear_operator(M)
+
+    if isinstance(Minv, LinearOperator):
+        Minv = wrap_linear_operator(Minv)
+
+    if isinstance(Ml, LinearOperator):
+        Ml = wrap_linear_operator(Ml)
+
+    if isinstance(Mr, LinearOperator):
+        Mr = wrap_linear_operator(Mr)
+
+    if inner_product:
+        inner_product = wrap_inner_product(inner_product)
+
+    # Make sure that the input vectors have two dimensions
+    if U is not None:
+        U = U.reshape(U.shape[0], -1)
+    if x0 is not None:
+        x0 = x0.reshape(U.shape[0], -1)
+
+    linear_system = LinearSystem(
+        A=A,
+        b=b,
+        M=M,
+        Minv=Minv,
+        Ml=Ml,
+        ip_B=inner_product,
+        exact_solution=exact_solution,
+    )
+    if U is None:
+        out = Gmres(
+            linear_system,
+            ortho=ortho,
+            x0=x0,
+            tol=tol,
+            maxiter=maxiter,
+            explicit_residual=use_explicit_residual,
+            store_arnoldi=store_arnoldi,
+        )
+    else:
+        out = DeflatedGmres(
+            linear_system,
+            ortho=ortho,
+            x0=x0,
+            U=U,
+            tol=tol,
+            maxiter=maxiter,
+            explicit_residual=use_explicit_residual,
+            store_arnoldi=store_arnoldi,
+        )
+
+    # Flatten a bunch of unnecessarily augmented vectors
+    out.x0 = out.x0.reshape(-1)
+    out.xk = out.xk.reshape(-1)
+    out.MMlr0 = out.MMlr0.reshape(-1)
+    out.Mlr0 = out.Mlr0.reshape(-1)
+    return out

--- a/krypy/linsys.py
+++ b/krypy/linsys.py
@@ -526,6 +526,25 @@ class Cg(_KrylovSolver):
                           'linear system. Consider using Minres or Gmres.')
         super(Cg, self).__init__(linear_system, **kwargs)
 
+    def __repr__(self):
+        string = "krypy CG object\n"
+        string += "    MMlr0 = [{}, ..., {}]\n".format(self.MMlr0[0], self.MMlr0[-1])
+        string += "    MMlr0_norm = {}\n".format(self.MMlr0_norm)
+        string += "    MlAMr: {} x {} matrix\n".format(*self.MlAMr.shape)
+        string += "    Mlr0: [{}, ..., {}]\n".format(self.Mlr0[0], self.Mlr0[-1])
+        string += "    flat_vecs: {}\n".format(self.flat_vecs)
+        string += "    store_arnoldi: {}\n".format(self.store_arnoldi)
+        string += "    tol: {}\n".format(self.tol)
+        string += "    maxiter: {}\n".format(self.maxiter)
+        string += "    iter: {}\n".format(self.iter)
+        string += "    explicit residual: {}\n".format(self.explicit_residual)
+        string += "    resnorms: [{}, ..., {}]\n".format(
+            self.resnorms[0], self.resnorms[-1]
+        )
+        string += "    x0: [{}, ..., {}]\n".format(self.x0[0], self.x0[-1])
+        string += "    xk: [{}, ..., {}]".format(self.xk[0], self.xk[-1])
+        return string
+
     def _solve(self):
         N = self.linear_system.N
 
@@ -704,6 +723,26 @@ class Minres(_KrylovSolver):
         self.ortho = ortho
         super(Minres, self).__init__(linear_system, **kwargs)
 
+    def __repr__(self):
+        string = "krypy MINRES object\n"
+        string += "    MMlr0 = [{}, ..., {}]\n".format(self.MMlr0[0], self.MMlr0[-1])
+        string += "    MMlr0_norm = {}\n".format(self.MMlr0_norm)
+        string += "    MlAMr: {} x {} matrix\n".format(*self.MlAMr.shape)
+        string += "    Mlr0: [{}, ..., {}]\n".format(self.Mlr0[0], self.Mlr0[-1])
+        string += "    flat_vecs: {}\n".format(self.flat_vecs)
+        string += "    store_arnoldi: {}\n".format(self.store_arnoldi)
+        string += "    ortho: {}\n".format(self.ortho)
+        string += "    tol: {}\n".format(self.tol)
+        string += "    maxiter: {}\n".format(self.maxiter)
+        string += "    iter: {}\n".format(self.iter)
+        string += "    explicit residual: {}\n".format(self.explicit_residual)
+        string += "    resnorms: [{}, ..., {}]\n".format(
+            self.resnorms[0], self.resnorms[-1]
+        )
+        string += "    x0: [{}, ..., {}]\n".format(self.x0[0], self.x0[-1])
+        string += "    xk: [{}, ..., {}]".format(self.xk[0], self.xk[-1])
+        return string
+
     def _solve(self):
         N = self.linear_system.N
 
@@ -827,6 +866,28 @@ class Gmres(_KrylovSolver):
         '''
         self.ortho = ortho
         super(Gmres, self).__init__(linear_system, **kwargs)
+
+    def __repr__(self):
+        string = "krypy GMRES object\n"
+        string += "    MMlr0 = [{}, ..., {}]\n".format(self.MMlr0[0], self.MMlr0[-1])
+        string += "    MMlr0_norm = {}\n".format(self.MMlr0_norm)
+        string += "    MlAMr: {} x {} matrix\n".format(*self.MlAMr.shape)
+        string += "    Mlr0: [{}, ..., {}]\n".format(self.Mlr0[0], self.Mlr0[-1])
+        string += "    R: {} x {} matrix\n".format(*self.R.shape)
+        string += "    V: {} x {} matrix\n".format(*self.V.shape)
+        string += "    flat_vecs: {}\n".format(self.flat_vecs)
+        string += "    store_arnoldi: {}\n".format(self.store_arnoldi)
+        string += "    ortho: {}\n".format(self.ortho)
+        string += "    tol: {}\n".format(self.tol)
+        string += "    maxiter: {}\n".format(self.maxiter)
+        string += "    iter: {}\n".format(self.iter)
+        string += "    explicit residual: {}\n".format(self.explicit_residual)
+        string += "    resnorms: [{}, ..., {}]\n".format(
+            self.resnorms[0], self.resnorms[-1]
+        )
+        string += "    x0: [{}, ..., {}]\n".format(self.x0[0], self.x0[-1])
+        string += "    xk: [{}, ..., {}]".format(self.xk[0], self.xk[-1])
+        return string
 
     def _get_xk(self, y):
         if y is None:

--- a/krypy/tests/test_convenience_wrappers.py
+++ b/krypy/tests/test_convenience_wrappers.py
@@ -3,15 +3,10 @@ import numpy
 import pytest
 
 
-@pytest.mark.parametrize(
-    "method, ref",
-    [
-        (krypy.cg, [1004.1873775173957, 1000.0003174916551, 999.9999999997555]),
-        (krypy.minres, [1004.187372488912, 1000.0003124632159, 999.9999949713145]),
-        (krypy.gmres, [1004.1873724888546, 1000.0003124630923, 999.999994971191]),
-    ],
-)
-def test_matrix(method, ref):
+def test_cg_matrix():
+    method = krypy.cg
+    ref = [1004.1873775173957, 1000.0003174916551, 999.9999999997555]
+
     A = numpy.diag([1.0e-3] + list(range(2, 101)))
     b = numpy.ones(100)
 
@@ -23,15 +18,76 @@ def test_matrix(method, ref):
     assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
 
 
-@pytest.mark.parametrize(
-    "method, ref",
-    [
-        (krypy.cg, [1004.1873775173271, 1000.0003174918709, 1000.0]),
-        (krypy.minres, [1004.1873774950692, 1000.0003174918709, 1000.0]),
-        (krypy.gmres, [1004.1873774950692, 1000.0003174918709, 1000.0]),
-    ],
-)
-def test_gmres(method, ref):
+def test_minres_matrix():
+    method = krypy.minres
+    ref = [1004.187372488912, 1000.0003124632159, 999.9999949713145]
+
+    A = numpy.diag([1.0e-3] + list(range(2, 101)))
+    b = numpy.ones(100)
+
+    out = method(A, b)
+    print(out)
+
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+
+
+def test_gmres_matrix():
+    method = krypy.gmres
+    ref = [1004.1873724888546, 1000.0003124630923, 999.999994971191]
+
+    A = numpy.diag([1.0e-3] + list(range(2, 101)))
+    b = numpy.ones(100)
+
+    out = method(A, b)
+    print(out)
+
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+
+
+def test_deflate_cg():
+    method = krypy.cg
+    ref = [1004.1873775173271, 1000.0003174918709, 1000.0]
+
+    n = 100
+    A = numpy.diag([1.0e-3] + list(range(2, n + 1)))
+    b = numpy.ones(n)
+
+    # deflate out the vector that belongs to the small eigenvalue
+    U = numpy.zeros(n)
+    U[0] = 1.0
+    out = method(A, b, U=U)
+
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+
+
+def test_deflate_minres():
+    method = krypy.minres
+    ref = [1004.1873774950692, 1000.0003174918709, 1000.0]
+
+    n = 100
+    A = numpy.diag([1.0e-3] + list(range(2, n + 1)))
+    b = numpy.ones(n)
+
+    # deflate out the vector that belongs to the small eigenvalue
+    U = numpy.zeros(n)
+    U[0] = 1.0
+    out = method(A, b, U=U)
+
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+
+
+def test_deflate_gmres():
+    method = krypy.gmres
+    ref = [1004.1873774950692, 1000.0003174918709, 1000.0]
+
     n = 100
     A = numpy.diag([1.0e-3] + list(range(2, n + 1)))
     b = numpy.ones(n)

--- a/krypy/tests/test_convenience_wrappers.py
+++ b/krypy/tests/test_convenience_wrappers.py
@@ -8,11 +8,19 @@ def test_cg_matrix():
     ref = [1004.1873775173957, 1000.0003174916551, 999.9999999997555]
 
     A = numpy.diag([1.0e-3] + list(range(2, 101)))
+
+    # Make sure the shapes are alright
+    b = numpy.ones((100, 1))
+    out = method(A, b, inner_product=numpy.dot)
+    assert out.x0.shape == b.shape
+    assert out.xk.shape == b.shape
+
     b = numpy.ones(100)
+    out = method(A, b, inner_product=numpy.dot)
+    assert out.x0.shape == b.shape
+    assert out.xk.shape == b.shape
 
-    out = method(A, b)
-    print(out)
-
+    out = method(A, b, inner_product=numpy.dot)
     assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
     assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
     assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]

--- a/krypy/tests/test_convenience_wrappers.py
+++ b/krypy/tests/test_convenience_wrappers.py
@@ -1,0 +1,64 @@
+import krypy
+import numpy
+import pytest
+
+
+@pytest.mark.parametrize(
+    "method, ref",
+    [
+        (krypy.cg, [1004.1873775173957, 1000.0003174916551, 999.9999999997555]),
+        (krypy.minres, [1004.187372488912, 1000.0003124632159, 999.9999949713145]),
+        (krypy.gmres, [1004.1873724888546, 1000.0003124630923, 999.999994971191]),
+    ],
+)
+def test_matrix(method, ref):
+    A = numpy.diag([1.0e-3] + list(range(2, 101)))
+    b = numpy.ones(100)
+
+    out = method(A, b)
+    print(out)
+
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+
+
+@pytest.mark.parametrize(
+    "method, ref",
+    [
+        (krypy.cg, [1004.1873775173271, 1000.0003174918709, 1000.0]),
+        (krypy.minres, [1004.1873774950692, 1000.0003174918709, 1000.0]),
+        (krypy.gmres, [1004.1873774950692, 1000.0003174918709, 1000.0]),
+    ],
+)
+def test_gmres(method, ref):
+    n = 100
+    A = numpy.diag([1.0e-3] + list(range(2, n + 1)))
+    b = numpy.ones(n)
+
+    # deflate out the vector that belongs to the small eigenvalue
+    U = numpy.zeros(n)
+    U[0] = 1.0
+    out = method(A, b, U=U)
+
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+
+
+def test_custom_inner_product():
+    n = 100
+    A = numpy.diag([1.0e-3] + list(range(2, n + 1)))
+    b = numpy.ones(n)
+
+    def inner(a, b):
+        return numpy.dot(a, b)
+
+    out = krypy.cg(A, b, inner_product=inner)
+
+    ref = 1004.1873775173957
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref) < 1.0e-12 * ref
+    ref = 1000.0003174916551
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref) < 1.0e-12 * ref
+    ref = 999.9999999997555
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref) < 1.0e-12 * ref

--- a/krypy/tests/test_convenience_wrappers.py
+++ b/krypy/tests/test_convenience_wrappers.py
@@ -1,9 +1,9 @@
 import krypy
 import numpy
-import pytest
 
 
 def test_cg_matrix():
+    tol = 1.0e-11
     method = krypy.cg
     ref = [1004.1873775173957, 1000.0003174916551, 999.9999999997555]
 
@@ -13,12 +13,13 @@ def test_cg_matrix():
     out = method(A, b)
     print(out)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
 
 
 def test_minres_matrix():
+    tol = 1.0e-11
     method = krypy.minres
     ref = [1004.187372488912, 1000.0003124632159, 999.9999949713145]
 
@@ -28,12 +29,13 @@ def test_minres_matrix():
     out = method(A, b)
     print(out)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
 
 
 def test_gmres_matrix():
+    tol = 1.0e-11
     method = krypy.gmres
     ref = [1004.1873724888546, 1000.0003124630923, 999.999994971191]
 
@@ -43,12 +45,13 @@ def test_gmres_matrix():
     out = method(A, b)
     print(out)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
 
 
 def test_deflate_cg():
+    tol = 1.0e-11
     method = krypy.cg
     ref = [1004.1873775173271, 1000.0003174918709, 1000.0]
 
@@ -61,12 +64,13 @@ def test_deflate_cg():
     U[0] = 1.0
     out = method(A, b, U=U)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
 
 
 def test_deflate_minres():
+    tol = 1.0e-11
     method = krypy.minres
     ref = [1004.1873774950692, 1000.0003174918709, 1000.0]
 
@@ -79,12 +83,13 @@ def test_deflate_minres():
     U[0] = 1.0
     out = method(A, b, U=U)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
 
 
 def test_deflate_gmres():
+    tol = 1.0e-11
     method = krypy.gmres
     ref = [1004.1873774950692, 1000.0003174918709, 1000.0]
 
@@ -97,12 +102,13 @@ def test_deflate_gmres():
     U[0] = 1.0
     out = method(A, b, U=U)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < 1.0e-12 * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < 1.0e-12 * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < 1.0e-12 * ref[2]
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
 
 
 def test_custom_inner_product():
+    tol = 1.0e-11
     n = 100
     A = numpy.diag([1.0e-3] + list(range(2, n + 1)))
     b = numpy.ones(n)
@@ -113,8 +119,8 @@ def test_custom_inner_product():
     out = krypy.cg(A, b, inner_product=inner)
 
     ref = 1004.1873775173957
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref) < 1.0e-12 * ref
+    assert abs(numpy.sum(numpy.abs(out.xk)) - ref) < tol * ref
     ref = 1000.0003174916551
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref) < 1.0e-12 * ref
+    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref) < tol * ref
     ref = 999.9999999997555
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref) < 1.0e-12 * ref
+    assert abs(numpy.max(numpy.abs(out.xk)) - ref) < tol * ref

--- a/krypy/tests/test_convenience_wrappers.py
+++ b/krypy/tests/test_convenience_wrappers.py
@@ -11,19 +11,17 @@ def test_cg_matrix():
 
     # Make sure the shapes are alright
     b = numpy.ones((100, 1))
-    out = method(A, b, inner_product=numpy.dot)
-    assert out.x0.shape == b.shape
-    assert out.xk.shape == b.shape
+    sol, _ = method(A, b, inner_product=numpy.dot)
+    assert sol.shape == b.shape
 
     b = numpy.ones(100)
-    out = method(A, b, inner_product=numpy.dot)
-    assert out.x0.shape == b.shape
-    assert out.xk.shape == b.shape
+    sol, _ = method(A, b, inner_product=numpy.dot)
+    assert sol.shape == b.shape
 
-    out = method(A, b, inner_product=numpy.dot)
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
+    sol, _ = method(A, b, inner_product=numpy.dot)
+    assert abs(numpy.sum(numpy.abs(sol)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(sol, sol)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(sol)) - ref[2]) < tol * ref[2]
 
 
 def test_minres_matrix():
@@ -34,12 +32,11 @@ def test_minres_matrix():
     A = numpy.diag([1.0e-3] + list(range(2, 101)))
     b = numpy.ones(100)
 
-    out = method(A, b)
-    print(out)
+    sol, _ = method(A, b)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
+    assert abs(numpy.sum(numpy.abs(sol)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(sol, sol)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(sol)) - ref[2]) < tol * ref[2]
 
 
 def test_gmres_matrix():
@@ -50,12 +47,11 @@ def test_gmres_matrix():
     A = numpy.diag([1.0e-3] + list(range(2, 101)))
     b = numpy.ones(100)
 
-    out = method(A, b)
-    print(out)
+    sol, _ = method(A, b)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
+    assert abs(numpy.sum(numpy.abs(sol)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(sol, sol)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(sol)) - ref[2]) < tol * ref[2]
 
 
 def test_deflate_cg():
@@ -70,11 +66,11 @@ def test_deflate_cg():
     # deflate out the vector that belongs to the small eigenvalue
     U = numpy.zeros(n)
     U[0] = 1.0
-    out = method(A, b, U=U)
+    sol, _ = method(A, b, U=U)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
+    assert abs(numpy.sum(numpy.abs(sol)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(sol, sol)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(sol)) - ref[2]) < tol * ref[2]
 
 
 def test_deflate_minres():
@@ -89,11 +85,11 @@ def test_deflate_minres():
     # deflate out the vector that belongs to the small eigenvalue
     U = numpy.zeros(n)
     U[0] = 1.0
-    out = method(A, b, U=U)
+    sol, _ = method(A, b, U=U)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
+    assert abs(numpy.sum(numpy.abs(sol)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(sol, sol)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(sol)) - ref[2]) < tol * ref[2]
 
 
 def test_deflate_gmres():
@@ -108,11 +104,11 @@ def test_deflate_gmres():
     # deflate out the vector that belongs to the small eigenvalue
     U = numpy.zeros(n)
     U[0] = 1.0
-    out = method(A, b, U=U)
+    sol, _ = method(A, b, U=U)
 
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref[0]) < tol * ref[0]
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref[1]) < tol * ref[1]
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref[2]) < tol * ref[2]
+    assert abs(numpy.sum(numpy.abs(sol)) - ref[0]) < tol * ref[0]
+    assert abs(numpy.sqrt(numpy.dot(sol, sol)) - ref[1]) < tol * ref[1]
+    assert abs(numpy.max(numpy.abs(sol)) - ref[2]) < tol * ref[2]
 
 
 def test_custom_inner_product():
@@ -124,11 +120,11 @@ def test_custom_inner_product():
     def inner(a, b):
         return numpy.dot(a, b)
 
-    out = krypy.cg(A, b, inner_product=inner)
+    sol, _ = krypy.cg(A, b, inner_product=inner)
 
     ref = 1004.1873775173957
-    assert abs(numpy.sum(numpy.abs(out.xk)) - ref) < tol * ref
+    assert abs(numpy.sum(numpy.abs(sol)) - ref) < tol * ref
     ref = 1000.0003174916551
-    assert abs(numpy.sqrt(numpy.dot(out.xk, out.xk)) - ref) < tol * ref
+    assert abs(numpy.sqrt(numpy.dot(sol, sol)) - ref) < tol * ref
     ref = 999.9999999997555
-    assert abs(numpy.max(numpy.abs(out.xk)) - ref) < tol * ref
+    assert abs(numpy.max(numpy.abs(sol)) - ref) < tol * ref

--- a/krypy/utils.py
+++ b/krypy/utils.py
@@ -378,8 +378,8 @@ class Givens:
         if x.shape != (2, 1):
             raise ArgumentError('x is not a vector of shape (2,1)')
 
-        a = numpy.asscalar(x[0])
-        b = numpy.asscalar(x[1])
+        a = x[0].item()
+        b = x[1].item()
         # real vector
         if numpy.isreal(x).all():
             a = numpy.real(a)


### PR DESCRIPTION
Okay, and here is the _actual_ thing that got me reinvested into krypy.

I've added some convenience wrappers to krypy that make it easier to use as a drop-in replancement for `numpy.solve` and friends. Now, you can simply use
```python
import krypy
out = krypy.cg(A, b)  # minres, gmres
```
and you're done; no more need for setting up `LinearSystem` and such.

The PR adapts the main readme too and fixes a small numpy deprecation (`asscalar` -> `item`).