### PR TITLE
setup.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/andrenarchy/krypy.png?branch=master)](https://travis-ci.org/andrenarchy/krypy)
 [![Documentation Status](https://readthedocs.org/projects/krypy/badge/?version=latest)](http://krypy.readthedocs.org/en/latest/?badge=latest)
 [![doi](https://zenodo.org/badge/doi/10.5281/zenodo.10283.png)](https://zenodo.org/record/10283)
+[![PyPI pyversions](https://img.shields.io/pypi/pyversions/krypy.svg)](https://pypi.org/pypi/krypy/)
 [![Pypi version](https://img.shields.io/pypi/v/krypy.svg)](https://pypi.python.org/pypi/krypy)
 [![Pypi downloads](https://img.shields.io/pypi/dm/krypy.svg)](https://pypi.python.org/pypi/krypy)
 

--- a/krypy/__about__.py
+++ b/krypy/__about__.py
@@ -1,0 +1,10 @@
+try:
+    # Python 3.8
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata
+
+try:
+    __version__ = metadata.version("krypy")
+except Exception:
+    __version__ = "unknown"

--- a/krypy/__init__.py
+++ b/krypy/__init__.py
@@ -1,5 +1,7 @@
 from . import linsys, deflation, recycling, utils
 from ._convenience import cg, minres, gmres
+from .__about__ import __version__
 
-__all__ = ['linsys', 'deflation', 'recycling', 'utils', 'cg', 'minres', 'gmres']
-__version__ = '2.1.7'
+__all__ = [
+    'linsys', 'deflation', 'recycling', 'utils', 'cg', 'minres', 'gmres', '__version__'
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,38 @@
+[metadata]
+name = krypy
+version = 2.2.0
+author = André Gaul
+email = gaul@web-yard.de
+description = Krylov subspace methods for linear systems
+url = https://github.com/andrenarchy/krypy
+project_urls =
+    Code=https://github.com/andrenarchy/krypy
+    Issues=https://github.com/andrenarchy/krypy/issues
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+platforms = any
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Mathematics
+
+[options]
+packages = find:
+# importlib_metadata can be removed when we support Python 3.8+ only
+install_requires =
+    importlib_metadata
+    numpy >= 1.11
+    scipy >= 0.17
+python_requires = >=3.6
+setup_requires =
+    setuptools>=42
+    wheel

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,4 @@
-# Use setuptools for these commands (they don't work well or at all
-# with distutils).  For normal builds use distutils.
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
-
-setup(name='krypy',
-      packages=['krypy', 'krypy.recycling'],
-      version='2.1.7',
-      description='Krylov subspace methods for linear systems',
-      long_description=open('README.md').read(),
-      author='André Gaul',
-      author_email='gaul@web-yard.de',
-      url='https://github.com/andrenarchy/krypy',
-      install_requires=['numpy (>=1.11)', 'scipy (>=0.17)'],
-      python_requires=">=3.6",
-      classifiers=[
-          'Development Status :: 4 - Beta',
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: MIT License',
-          'Operating System :: OS Independent',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Topic :: Scientific/Engineering :: Mathematics'
-          ],
-      )
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
Move all meta data into `setup.cfg`. This makes it easier for other tools to retrieve the data which can now simply be _parsed_ from a file instead of having to _evaluate_ one. Also, make sure the version number is in one place only.