### PR TITLE
Updating Datatypes for Compatibility with NumPy >=1.24.0

### DIFF
--- a/krypy/__init__.py
+++ b/krypy/__init__.py
@@ -1,4 +1,4 @@
-from . import deflation, linsys, recycling, utils
+from . import deflation, linsys, recycling, utils, mfuncs
 from .__about__ import __version__
 from ._convenience import cg, gmres, minres
 
@@ -10,5 +10,6 @@ __all__ = [
     "cg",
     "minres",
     "gmres",
+    "mfuncs",
     "__version__",
 ]

--- a/krypy/linsys.py
+++ b/krypy/linsys.py
@@ -71,7 +71,7 @@ class LinearSystem(object):
           ``exact_solution.shape == (N,1)``. Then error norms can be computed
           (for debugging or research purposes). Defaults to ``None``.
         """
-        self.N = N = b.shape[0]
+        self.N = N = len(b)
         """Dimension :math:`N` of the space :math:`\\mathbb{C}^N` where the
         linear system is defined."""
         shape = (N, N)

--- a/krypy/linsys.py
+++ b/krypy/linsys.py
@@ -71,7 +71,7 @@ class LinearSystem(object):
           ``exact_solution.shape == (N,1)``. Then error norms can be computed
           (for debugging or research purposes). Defaults to ``None``.
         """
-        self.N = N = len(b)
+        self.N = N = b.shape[0]
         """Dimension :math:`N` of the space :math:`\\mathbb{C}^N` where the
         linear system is defined."""
         shape = (N, N)

--- a/krypy/mfuncs.py
+++ b/krypy/mfuncs.py
@@ -1,0 +1,139 @@
+from . import utils
+import numpy
+import scipy.linalg
+import scipy.sparse
+import numbers
+
+__all__ = [
+    "MatrixFunction",
+    "MatrixExponential",
+    "MatrixInverse",
+    "MatrixFunctionSystem",
+    "MatrixFunctionUpdate"
+]
+
+# Sparse matrix??
+class MatrixFunction:
+    """DOCSTRING?"""
+    def __init__(
+            self,
+            f,
+            f_description=None,
+            implementation="scipy"
+    ):
+        """DOCSTRING?"""
+        self.f = numpy.vectorize(f)
+        self.f_description = f_description
+        self.implementation = implementation
+
+    def _evaluate_general(self, A):
+        if self.implementation == "scipy":
+            return scipy.linalg.funm(A, self.f)
+        else:
+            raise NotImplementedError("Unknown implementation:"
+                                      + " {}".format(self.implementation))
+
+    def _evaluate_hermitian(self, A, is_positive_semidefinite=False):
+        """From scipy notes*** NEED TO CITE"""
+        w, v = scipy.linalg.eigh(A, check_finite=True)
+        if is_positive_semidefinite:
+            w = numpy.maximum(w, 0)
+        w = self.f(w)
+        return (v * w) @ v.conj().T
+
+    def _evaluate_general_sparse(self, A_sp):
+        raise NotImplementedError("Unknown sparse implementation:"
+                                  + " {}".format(self.implementation))
+
+    def _evaluate_hermitian_sparse(self, A_sp, is_positive_semidefinite=False):
+        raise NotImplementedError("Unknown sparse implementation:"
+                                  + " {}".format(self.implementation))
+
+    def __call__(self, A, is_hermitian=False, is_positive_semidefinite=False):
+        """Compute matrix function of current matrix with defined method"""
+        is_sparse = scipy.sparse.issparse(A)
+        if is_hermitian and is_sparse:
+            return self._evaluate_hermitian_sparse(A, is_positive_semidefinite)
+        elif is_hermitian and not is_sparse:
+            return self._evaluate_hermitian(A, is_positive_semidefinite)
+        elif not is_hermitian and is_sparse:
+            return self._evaluate_general_sparse(A)
+        else:
+            return self._evaluate_general(A)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        if self.f_description:
+            return str(type(self).__name__) + "({})".format(self.f_description)
+        else:
+            return str(type(self).__name__) + "({})".format(str(self.f))
+
+
+class MatrixExponential(MatrixFunction):
+    f_description = "numpy.exp(x)"
+    f = numpy.exp
+
+    def __init__(self,
+                 display_error_estimate=False,
+                 implementation="scipy"):
+        self.implementation = implementation
+
+    def _evaluate_general(self, A):
+        if self.implementation == "scipy":
+            return scipy.linalg.expm(A)
+        else:
+            raise NotImplementedError("Unknown evaluation algorithm:"
+                                      + " {}".format(self.implementation))
+
+    def _evaluate_hermitian(self, A, is_positive_semidefinite=False):
+        """From scipy notes*** NEED TO CITE"""
+        if self.implementation == "scipy":
+            return scipy.linalg.expm(A)
+        elif self.implementation == "diagonalizable":
+            super()._evaluate_hermitian(A, is_positive_semidefinite)
+        else:
+            raise NotImplementedError("Unknown evaluation algorithm:"
+                                      + " {}".format(self.implementation))
+
+    def _evaluate_general_sparse(self, A_sp):
+        return scipy.sparse.linalg.expm(A_sp)
+
+    def _evaluate_hermitian_sparse(self, A_sp, is_positive_semidefinite=False):
+        raise NotImplementedError("Unknown sparse implementation:"
+                                  + " {}".format(self.implementation))
+
+
+class MatrixInverse(MatrixFunction):
+    f_description = "1/x"
+    def f(x: any) -> any: return 1/x
+
+    def __init__(self,
+                 implementation="scipy"):
+        self.implementation = implementation
+
+    def _evaluate_general(self, A):
+        if self.implementation == "scipy":
+            return scipy.linalg.inv(A)
+        else:
+            raise NotImplementedError("Unknown evaluation algorithm:"
+                                      + " {}".format(self.implementation))
+
+    def _evaluate_hermitian(self, A, is_positive_semidefinite=False):
+        """From scipy notes*** NEED TO CITE"""
+        if self.implementation == "scipy":
+            return scipy.linalg.inv(A)
+        elif self.implementation == "diagonalizable":
+            super()._evaluate_hermitian(A, is_positive_semidefinite)
+        else:
+            raise NotImplementedError("Unknown evaluation algorithm:"
+                                      + " {}".format(self.implementation))
+
+
+class MatrixFunctionSystem:
+    pass
+
+
+class MatrixFunctionUpdate:
+    pass

--- a/krypy/utils.py
+++ b/krypy/utils.py
@@ -1258,8 +1258,8 @@ def ritz(H, V=None, hermitian=False, type="ritz"):
         for i in range(n):
             U[:, i] /= numpy.linalg.norm(U[:, i], 2)
             resi = numpy.dot(H, U[:, i])
-            if resi.dtype != numpy.complex and theta.dtype == numpy.complex:
-                resi = numpy.array(resi, dtype=numpy.complex)
+            if resi.dtype != complex and theta.dtype == complex:
+                resi = numpy.array(resi, dtype=complex)
             resi[:n] -= theta[i] * U[:, i]
             resnorm.append(numpy.linalg.norm(resi, 2))
         resnorm = numpy.array(resnorm)
@@ -1890,7 +1890,7 @@ class BoundCG(object):
             raise AssumptionError("non-real eigenvalues not allowed")
 
         # sort
-        evals = numpy.sort(numpy.array(evals, dtype=numpy.float))
+        evals = numpy.sort(numpy.array(evals, dtype=float))
 
         # normalize
         evals /= evals[-1]
@@ -1977,7 +1977,7 @@ class BoundMinres(object):
             raise AssumptionError("non-real eigenvalues not allowed")
 
         # sort
-        evals = numpy.sort(numpy.array(evals, dtype=numpy.float))
+        evals = numpy.sort(numpy.array(evals, dtype=float))
 
         # normalize and categorize evals
         evals /= numpy.max(numpy.abs(evals))
@@ -2086,7 +2086,7 @@ class NormalizedRootsPolynomial(object):
         # values
         for j in range(vals.shape[1]):
             sort_tmp = numpy.argsort(numpy.abs(vals[:, j]))
-            sort = numpy.zeros((n,), dtype=numpy.int)
+            sort = numpy.zeros((n,), dtype=int)
             mid = int(numpy.ceil(float(n) / 2))
             sort[::2] = sort_tmp[:mid]
             sort[1::2] = sort_tmp[mid:][::-1]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,7 +18,7 @@ def get_matrix_spd():
 
 
 def get_matrix_hpd():
-    a = numpy.array(numpy.linspace(1, 2, 10), dtype=numpy.complex)
+    a = numpy.array(numpy.linspace(1, 2, 10), dtype=complex)
     a[0] = 5
     a[-1] = 1e-1
     A = numpy.diag(a)
@@ -34,7 +34,7 @@ def get_matrix_symm_indef():
 
 
 def get_matrix_herm_indef():
-    a = numpy.array(numpy.linspace(1, 2, 10), dtype=numpy.complex)
+    a = numpy.array(numpy.linspace(1, 2, 10), dtype=complex)
     a[-1] = 1e-3
     A = numpy.diag(a)
     A[-1, 0] = 10j
@@ -43,7 +43,7 @@ def get_matrix_herm_indef():
 
 
 def get_matrix_nonsymm():
-    a = numpy.array(range(1, 11), dtype=numpy.float)
+    a = numpy.array(range(1, 11), dtype=float)
     a[-1] = -1e1
     A = numpy.diag(a)
     A[0, -1] = 1e1
@@ -51,7 +51,7 @@ def get_matrix_nonsymm():
 
 
 def get_matrix_comp_nonsymm():
-    a = numpy.array(range(1, 11), dtype=numpy.complex)
+    a = numpy.array(range(1, 11), dtype=complex)
     a[-1] = -1e1
     A = numpy.diag(a)
     A[0, -1] = 1.0e1j


### PR DESCRIPTION
I have replaced usage of numpy.complex with built-in complex datatype, and the same for float and int. Now all tests are passed with newer versions of numpy (this run with numpy 1.24.3). This fixes issue #83. 


```
=============================== test session starts ===============================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0

...

collected 25482 items                                                             

test/test_convenience_wrappers.py .......                                   [  0%]
test/test_deflation.py .................................................... [  0%]
........................................................................... [  0%]

...

........................................................................... [ 99%]
............................                                                [100%]

================================ warnings summary =================================
../sci_comp_project_venv/lib/python3.11/site-packages/krypy-2.2.0-py3.11.egg/krypy/utils.py:19
  /sci_comp_project_venv/lib/python3.11/site-packages/krypy-2.2.0-py3.11.egg/krypy/utils.py:19: DeprecationWarning: Please use `isintlike` from the `scipy.sparse` namespace, the `scipy.sparse.sputils` namespace is deprecated.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 25482 passed, 1 warning in 81.81s (0:01:21) ===================


```