### PR TITLE
Removed deprecated isintlike function from scipy.sparse.sputils

### DIFF
--- a/krypy/utils.py
+++ b/krypy/utils.py
@@ -16,7 +16,7 @@ import scipy.linalg.blas as blas
 from scipy.sparse import isspmatrix
 
 # from scipy.sparse.linalg import LinearOperator, aslinearoperator
-from scipy.sparse.sputils import isintlike
+# from scipy.sparse.sputils import isintlike
 
 __all__ = [
     "ArgumentError",
@@ -1369,7 +1369,7 @@ class LinearOperator(object):
     """
 
     def __init__(self, shape, dtype, dot=None, dot_adj=None):
-        if len(shape) != 2 or not isintlike(shape[0]) or not isintlike(shape[1]):
+        if len(shape) != 2 or int(shape[0]) != shape[0] or int(shape[1]) != shape[1]:
             raise LinearOperatorError("shape must be (m,n) with m and n " "integer")
         self.shape = shape
         self.dtype = numpy.dtype(dtype)  # defaults to float64
@@ -1525,7 +1525,7 @@ class _PowerLinearOperator(LinearOperator):
             raise LinearOperatorError("LinearOperator expected as A")
         if A.shape[0] != A.shape[1]:
             raise LinearOperatorError("square LinearOperator expected as A")
-        if not isintlike(p):
+        if int(p) != p:
             raise LinearOperatorError("integer expected as p")
         self.args = (A, p)
         super(_PowerLinearOperator, self).__init__(


### PR DESCRIPTION
Replaced deprecated integer test using isintlike by the test: int(value) = value.
Added option to store output vectors x_k after each iteration.